### PR TITLE
Replace string check with object instance check in the core logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,27 @@
 module.exports = function isMergeableObject(value) {
-	return isNonNullObject(value)
-		&& !isSpecial(value)
-}
+  return isNonNullObject(value) && !isSpecial(value);
+};
 
 function isNonNullObject(value) {
-	return !!value && typeof value === 'object'
+  return !!value && typeof value === 'object';
 }
-
 function isSpecial(value) {
-	var stringValue = Object.prototype.toString.call(value)
+  // var stringValue = Object.prototype.toString.call(value)
 
-	return stringValue === '[object RegExp]'
-		|| stringValue === '[object Date]'
-		|| isReactElement(value)
+  // return stringValue === '[object RegExp]'
+  // 	|| stringValue === '[object Date]'
+  // 	|| isReactElement(value)
+
+  // There is a better way to check for RegExp and Date objects .
+  return (
+    value instanceof RegExp || value instanceof Date || isReactElement(value)
+  );
 }
 
 // see https://github.com/facebook/react/blob/b5ac963fb791d1298e7f396236383bc955f916c1/src/isomorphic/classic/element/ReactElement.js#L21-L25
-var canUseSymbol = typeof Symbol === 'function' && Symbol.for
-var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7
+var canUseSymbol = typeof Symbol === 'function' && Symbol.for;
+var REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7;
 
 function isReactElement(value) {
-	return value.$$typeof === REACT_ELEMENT_TYPE
+  return value.$$typeof === REACT_ELEMENT_TYPE;
 }


### PR DESCRIPTION
In isSpecial method in index.js, type of objects such as RegExp and Date are checked with string comparisons. InstanceOf method can provide reliable results in my view.  